### PR TITLE
1.1 -- Fix(FusionExtension): Stop FusionExtension from making the tag lowercase.

### DIFF
--- a/code/extensions/FusionExtension.php
+++ b/code/extensions/FusionExtension.php
@@ -47,13 +47,12 @@ class FusionExtension extends DataExtension {
 
 		// Confirm that the tag has been given a title and doesn't already exist.
 
-		$this->owner->$validate = strtolower($this->owner->$validate);
 		if($result->valid() && !$this->owner->$validate) {
 			$result->error("\"{$validate}\" required!");
 		}
 		else if($result->valid() && $class::get_one($class, array(
 			'ID != ?' => $this->owner->ID,
-			"{$validate} = ?" => $this->owner->$validate
+			"LOWER({$validate}) = ?" => strtolower($this->owner->$validate)
 		))) {
 			$result->error('Tag already exists!');
 		}


### PR DESCRIPTION
Fix(FusionExtension): Stop FusionExtension from making the tag lowercase.

If you edit a TaxonomyTerm from the FusionTag interface, it will become lowercase.
If you edit a TaxonomyTerm from the TaxonomyTerm interface, it will retain its casing.

It still couples and modifies the FusionTag despite the non-matching casing due to wrapping the field in MySQL "LOWER()"