### PR TITLE
FIX Use by-id filtering for tagging extensions

### DIFF
--- a/code/extensions/CMSMainTaggingExtension.php
+++ b/code/extensions/CMSMainTaggingExtension.php
@@ -20,17 +20,34 @@ class CMSMainTaggingExtension extends Extension {
 		// Instantiate a field containing the existing tags.
 
 		$form->Fields()->insertBefore(ListboxField::create(
-			'q[Tagging]',
+			'q[FusionTags]',
 			'Tags',
-			FusionTag::get()->map('Title', 'Title')->toArray(),
-			(($filtering = $this->owner->getRequest()->getVar('q')) && isset($filtering['Tagging'])) ? $filtering['Tagging'] : array(),
+			FusionTag::get()->map('ID', 'Title')->toArray(),
+			(($filtering = $this->owner->getRequest()->getVar('q')) && isset($filtering['FusionTags'])) ? $filtering['FusionTags'] : array(),
 			null,
 			true
 		), 'q[Term]');
+        
+        $filterClass = $form->Fields()->dataFieldByName('q[FilterClass]');
+        $options = $filterClass->getSource();
+        unset($options['CMSSiteTreeFilter_Search']);
+        $filterClass->setSource($options);
 
 		// Allow extension.
 
 		$this->owner->extend('updateCMSMainTaggingExtensionSearchForm', $form);
 	}
 
+}
+
+class CMSSiteTreeFilterTagging_Search extends CMSSiteTreeFilter_Search {
+    public function getFilteredPages() {
+		$pages = parent::getFilteredPages();
+        if (isset($this->params['FusionTags']) && count($this->params['FusionTags'])) {
+            $pages = $pages->filter(array(
+                'FusionTags.ID' => $this->params['FusionTags']
+            ));
+        }
+        return $pages;
+	}
 }

--- a/code/extensions/TaggingExtension.php
+++ b/code/extensions/TaggingExtension.php
@@ -32,17 +32,17 @@ class TaggingExtension extends DataExtension {
 		// Instantiate a field containing the existing tags.
 
 		$fields = array_merge(array(
-			'Tagging' => array(
+			'FusionTags.ID' => array(
 				'title' => 'Tags',
 				'field' => ListboxField::create(
-					'Tagging',
+					'FusionTags.ID',
 					'Tags',
-					FusionTag::get()->map('Title', 'Title')->toArray(),
-					(($filtering = Controller::curr()->getRequest()->getVar('q')) && isset($filtering['Tagging'])) ? $filtering['Tagging'] : array(),
+					FusionTag::get()->map('ID', 'Title')->toArray(),
+					(($filtering = Controller::curr()->getRequest()->getVar('q')) && isset($filtering['FusionTags.ID'])) ? $filtering['FusionTags.ID'] : array(),
 					null,
 					true
 				),
-				'filter' => $this->owner->dbObject('Tagging')->stat('default_search_filter_class')
+				'filter' => 'ExactMatchFilter'
 			)
 		), $fields);
 

--- a/code/extensions/TaggingExtension.php
+++ b/code/extensions/TaggingExtension.php
@@ -30,8 +30,7 @@ class TaggingExtension extends DataExtension {
 	public function updateSearchableFields(&$fields) {
 
 		// Instantiate a field containing the existing tags.
-
-		$fields = array_merge(array(
+		$fields = array_merge($fields, array(
 			'FusionTags.ID' => array(
 				'title' => 'Tags',
 				'field' => ListboxField::create(
@@ -44,7 +43,7 @@ class TaggingExtension extends DataExtension {
 				),
 				'filter' => 'ExactMatchFilter'
 			)
-		), $fields);
+		));
 
 		// Allow extension.
 


### PR DESCRIPTION
Rather than using text-based searching for fusion tags, use the relationship
based filtering using the tag IDs. This prevents issues with the tag name
being restricted to only those that a ListBox field can support, and performs
exact tag filtering instead of partial text match filtering
